### PR TITLE
use v9 branch for backport

### DIFF
--- a/backport.py
+++ b/backport.py
@@ -266,7 +266,7 @@ def main(args):
         '--sha', default=None, type=str,
         help='The SHA hash of the merge commit. Exclusive with --pr')
     parser.add_argument(
-        '--branch', type=str, default='v8',
+        '--branch', type=str, default='v9',
         help='Target branch to make a backport')
     parser.add_argument(
         '--https', action='store_true', default=False,


### PR DESCRIPTION
Previous: https://github.com/cupy/backport/pull/18