### PR TITLE
Support sandbox repository for testing purposes

### DIFF
--- a/backport.py
+++ b/backport.py
@@ -291,7 +291,7 @@ def main(args):
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '--repo', required=True,
-        choices=('chainer', 'cupy', 'cupy-release-tools'),
+        choices=('chainer', 'cupy', 'cupy-release-tools', 'sandbox'),
         help='target repository')
     parser.add_argument(
         '--token', type=str, default=None,
@@ -332,6 +332,8 @@ def main(args):
         organ_name, repo_name = 'cupy', 'cupy'
     elif args.repo == 'cupy-release-tools':
         organ_name, repo_name = 'cupy', 'cupy-release-tools'
+    elif args.repo == 'sandbox':
+        organ_name, repo_name = 'chainer-ci', 'backport-sandbox'
     else:
         assert False
 


### PR DESCRIPTION
You can now test backport tool via `backport.py --repo sandbox --pr 1`.

https://github.com/chainer-ci/backport-sandbox/pull/1
https://github.com/chainer-ci/backport-sandbox/pull/2