### PR TITLE
fix backport ready for PyGithub 2

### DIFF
--- a/backport.py
+++ b/backport.py
@@ -90,7 +90,7 @@ def git(args: list[str], cd: Optional[str] = None) -> None:
     print('')
 
 
-class App(object):
+class App:
     def __init__(
             self, token: str, organ_name: str, repo_name: str,
             debug: bool = False):
@@ -98,7 +98,7 @@ class App(object):
         assert isinstance(repo_name, str)
         self.repo_name = repo_name
         self.organ_name = organ_name
-        self.g = github.Github(token)
+        self.g = github.Github(auth=github.Auth.Token(token))
         self.repo = self.g.get_repo('{}/{}'.format(organ_name, repo_name))
         self.user_name = self.g.get_user().login
         self.debug = debug


### PR DESCRIPTION
https://github.com/PyGithub/PyGithub/releases/tag/v1.59.0

> This release introduces new way of authentication. All authentication-related arguments github.Github(login_or_token=…, password=…, jwt=…, app_auth=…) and github.GithubIntegration(integration_id=…, private_key=…, jwt_expiry=…, jwt_issued_at=…, jwt_algorithm=…) are replaced by a single auth=… argument. Module github.Auth provides classes for all supported ways of authentication: Login, Token, AppAuth, AppAuthToken, AppInstallationAuth, AppUserAuth. Old arguments are deprecated but continue to work. They are scheduled for removal for version 2.0 release.
